### PR TITLE
Jw/backblaze region fix

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -77,7 +77,7 @@ defmodule ExAws.Config.Defaults do
   end
 
   @partitions [
-    {~r/^(us|eu|ap|sa|ca)\-\w+\-\d+$/, "aws"},
+    {~r/^(us|eu|ap|sa|ca)\-\w+\-(?!000$)\d+$/, "aws"},
     {~r/^cn\-\w+\-\d+$/, "aws-cn"},
     {~r/^us\-gov\-\w+\-\d+$/, "aws-us-gov"}
   ]


### PR DESCRIPTION
ex_aws has AWS-specific region validation in ExAws.Config.Defaults. E.g., ~r/^(us|eu|ap|sa|ca)\-\w+\-\d+$/ matches and validates against us-west-2. Unfortunately Backblaze has very similar region structure, us-west-000, which causes ex_aws to error out when validating that specific region. This PR updates the region regex to skip our specific backblaze region. I would just open a PR to enable backblaze specific regions, however, I am unsure how much region digit overlap there could be between AWS and Backblaze. Also, ex_aws admins are explicit about lib only caring about AWS-specific use cases.